### PR TITLE
Fixed missing 'babel-polyfill' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@angular/router": "^5.0.0",
     "@ledgerhq/hw-transport-u2f": "^4.7.3",
     "@types/crypto-js": "^3.1.38",
+    "babel-polyfill": "^6.26.0",
     "bignumber.js": "^5.0.0",
     "bip39": "^2.5.0",
     "blakejs": "^1.1.0",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -64,3 +64,4 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+ import 'babel-polyfill';


### PR DESCRIPTION
It seems something changed in the node.js default setup in ubuntu 18.04 and fresh installations of nanovault do not work anymore. After adding the 'babel-polyfill' dependency everything is fine again.