### PR TITLE
Send QR code encodes URL to Nanovault Send page with account pre-filled

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -137,7 +137,7 @@
           </div>
           <div class="uk-width-2-5@s uk-width-1-4@m uk-text-center">
             <img *ngIf="qrCodeImage" [src]="qrCodeImage"><br />
-            <span class="uk-text-small">Scan to receive Nano</span>
+            <span class="uk-text-small">Scan to send Nano</span>
           </div>
         </div>
 

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -123,9 +123,15 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.account.pendingFiat = this.util.nano.rawToMnano(this.account.pending || 0).times(this.price.price.lastPrice).toNumber();
     await this.getAccountHistory(this.accountID);
 
-
-    const qrCode = await QRCode.toDataURL(`${this.accountID}`);
+    let sendUrl = this.prepareSendToUrl(this.accountID);
+    const qrCode = await QRCode.toDataURL(sendUrl);
     this.qrCodeImage = qrCode;
+  }
+
+  // Prepare send-to URL, to our send route with account
+  prepareSendToUrl(account: string): string {
+    const urlStr = this.settings.getServerApiBaseUrl() + 'send?to=' + account;
+    return urlStr;
   }
 
   ngOnDestroy() {

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -115,7 +115,7 @@ export class ConfigureAppComponent implements OnInit {
   serverConfigurations = [
     {
       name: 'nanovault',
-      api: null,
+      api: 'https://nanovault.io/api/node-api',
       ws: null,
     },
     {

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -24,7 +24,8 @@ interface AppSettings {
 export class AppSettingsService {
   storeKey = `nanovault-appsettings`;
 
-  settings: AppSettings = {
+  // Default settings
+  defaultSettings: AppSettings = {
     displayDenomination: 'mnano',
     // displayPrefix: 'xrb',
     walletStore: 'localStorage',
@@ -39,6 +40,12 @@ export class AppSettingsService {
     serverWS: null,
     minimumReceive: null,
   };
+
+  // a deep copy clone of the default settings
+  cloneDefaultSettings() : AppSettings {
+    return JSON.parse(JSON.stringify(this.defaultSettings));
+  }
+  settings: AppSettings = this.cloneDefaultSettings(); // deep copy
 
   constructor() { }
 
@@ -77,21 +84,7 @@ export class AppSettingsService {
 
   clearAppSettings() {
     localStorage.removeItem(this.storeKey);
-    this.settings = {
-      displayDenomination: 'mnano',
-      // displayPrefix: 'xrb',
-      walletStore: 'localStorage',
-      displayCurrency: 'USD',
-      defaultRepresentative: null,
-      lockOnClose: 1,
-      lockInactivityMinutes: 30,
-      powSource: 'best',
-      serverName: 'nanovault',
-      serverNode: null,
-      serverAPI: null,
-      serverWS: null,
-      minimumReceive: null,
-    };
+    this.settings = this.cloneDefaultSettings(); // deep copy
   }
 
 }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import set = Reflect.set;
+import * as url from 'url';
 
 export type WalletStore = 'localStorage'|'none';
 export type PoWSource = 'server'|'clientCPU'|'clientWebGL'|'best';
@@ -87,4 +87,10 @@ export class AppSettingsService {
     this.settings = this.cloneDefaultSettings(); // deep copy
   }
 
+  // Get the base URL part of the serverAPI, e.g. https://nanovault.io from https://nanovault.io/api/node-api.
+  getServerApiBaseUrl(): string {
+    let u = url.parse(this.settings.serverAPI);
+    u.pathname = '/';
+    return url.format(u);
+  }
 }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -35,7 +35,7 @@ export class AppSettingsService {
     lockInactivityMinutes: 30,
     powSource: 'best',
     serverName: 'nanovault',
-    serverAPI: null,
+    serverAPI: 'https://nanovault.io/api/node-api',
     serverNode: null,
     serverWS: null,
     minimumReceive: null,


### PR DESCRIPTION
This is a simpler solution for Issue #76 : the QR code on the account detail page always encodes the URL of the form https://nanovault.io/send?to=xrb_aaa, so it points to a nanovault Send page with the target account prefilled.
A more complex solution (with configrable options) is in another PR (PR #78 ). 