### PR TITLE
Options for QR code: encode full Nanovault URL or accountID only

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -136,8 +136,18 @@
             </div>
           </div>
           <div class="uk-width-2-5@s uk-width-1-4@m uk-text-center">
-            <img *ngIf="qrCodeImage" [src]="qrCodeImage"><br />
-            <span class="uk-text-small">Scan to send Nano</span>
+            <span *ngIf="this.settings.settings.qrIntegration > 0">
+              <img *ngIf="qrCodeImage" [src]="qrCodeImage" title="{{qrCodeText}}"><br />
+              <span class="uk-text-small">Scan to send Nano</span>
+            </span>
+            <div>
+              <a class="uk-link-text uk-text-small uk-width-1-1" title="QR Code Integration">{{qrIntegrations[this.settings.settings.qrIntegration].text}}</a>
+              <div uk-dropdown>
+                <ul class="uk-nav uk-dropdown-nav">
+                  <li class="uk-active" *ngFor="let int of qrIntegrations" [class]="{ 'uk-active': this.settings.settings.qrIntegration == int.value }"><a href="#" (click)="updateQrIntegration(int.value)">{{int.text}}</a></li>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -137,7 +137,7 @@
           </div>
           <div class="uk-width-2-5@s uk-width-1-4@m uk-text-center">
             <img *ngIf="qrCodeImage" [src]="qrCodeImage"><br />
-            <span class="uk-text-small">Scan to receive Nano</span>
+            <span class="uk-text-small">Scan to send Nano</span>
           </div>
         </div>
 

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -123,9 +123,15 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.account.pendingFiat = this.util.nano.rawToMnano(this.account.pending || 0).times(this.price.price.lastPrice).toNumber();
     await this.getAccountHistory(this.accountID);
 
-
-    const qrCode = await QRCode.toDataURL(`${this.accountID}`);
+    let sendUrl = this.prepareSendToUrl(this.accountID);
+    const qrCode = await QRCode.toDataURL(sendUrl);
     this.qrCodeImage = qrCode;
+  }
+
+  // Prepare send-to URL, to our send route with account
+  prepareSendToUrl(account: string): string {
+    const urlStr = this.settings.getServerApiBaseUrl() + 'send?to=' + account;
+    return urlStr;
   }
 
   ngOnDestroy() {

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -25,6 +25,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   pendingBlocks = [];
   pageSize = 25;
   maxPageSize = 200;
+  qrIntegrations = this.settings.qrIntegrations;
 
   repLabel: any = '';
   addressBookEntry: any = null;
@@ -43,6 +44,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   isNaN = isNaN;
 
   qrCodeImage = null;
+  qrCodeText = null;
 
   routerSub = null;
   priceSub = null;
@@ -123,8 +125,24 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.account.pendingFiat = this.util.nano.rawToMnano(this.account.pending || 0).times(this.price.price.lastPrice).toNumber();
     await this.getAccountHistory(this.accountID);
 
-    let sendUrl = this.prepareSendToUrl(this.accountID);
-    const qrCode = await QRCode.toDataURL(sendUrl);
+    await this.generateQR();
+  }
+
+  // Generate the QR code image, depending on the QR integration style
+  async generateQR() {
+    const style = this.settings.settings.qrIntegration;
+    if (style == 0) {
+      this.qrCodeImage = null;
+      this.qrCodeText = null;
+      return;
+    }
+    this.qrCodeText = '?'
+    switch (style) {
+      default:
+      case 1: this.qrCodeText = this.accountID; break;
+      case 2: this.qrCodeText = this.prepareSendToUrl(this.accountID); break;
+    }
+    const qrCode = await QRCode.toDataURL(this.qrCodeText);
     this.qrCodeImage = qrCode;
   }
 
@@ -132,6 +150,14 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   prepareSendToUrl(account: string): string {
     const urlStr = this.settings.getServerApiBaseUrl() + 'send?to=' + account;
     return urlStr;
+  }
+
+  async updateQrIntegration(newIntValue) {
+    // save to here, and to settings
+    this.settings.settings.qrIntegration = newIntValue;
+    this.settings.saveAppSettings();
+    // regenerate QR code
+    this.generateQR();
   }
 
   ngOnDestroy() {

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -41,6 +41,19 @@
             </div>
           </div>
 
+          <div class="uk-width-1-1">
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="form-horizontal-select">QR Code Integration <span uk-icon="icon: info;" uk-tooltip title="Integration style used in the URLs encoded in Account QR code"></span></label>
+                <div class="uk-form-controls">
+                  <select class="uk-select" [(ngModel)]="selectedQrIntegration" id="form-horizontal-select">
+                    <option *ngFor="let int of qrIntegrations" [value]="int.value">{{int.text}}</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!--<div class="uk-width-1-1">-->
             <!--<div class="uk-form-horizontal">-->
 

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -115,7 +115,7 @@ export class ConfigureAppComponent implements OnInit {
   serverConfigurations = [
     {
       name: 'nanovault',
-      api: null,
+      api: 'https://nanovault.io/api/node-api',
       ws: null,
     },
     {

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -74,6 +74,9 @@ export class ConfigureAppComponent implements OnInit {
   ];
   selectedCurrency = this.currencies[0].value;
 
+  qrIntegrations = this.appSettings.qrIntegrations;
+  selectedQrIntegration = 0;
+
   inactivityOptions = [
     { name: 'Never', value: 0 },
     { name: '1 Minute', value: 1 },
@@ -162,6 +165,8 @@ export class ConfigureAppComponent implements OnInit {
     const matchingCurrency = this.currencies.find(d => d.value === settings.displayCurrency);
     this.selectedCurrency = matchingCurrency.value || this.currencies[0].value;
 
+    this.selectedQrIntegration = settings.qrIntegration;
+
     const matchingDenomination = this.denominations.find(d => d.value == settings.displayDenomination);
     this.selectedDenomination = matchingDenomination.value || this.denominations[0].value;
 
@@ -193,6 +198,7 @@ export class ConfigureAppComponent implements OnInit {
     // const updatePrefixes = this.appSettings.settings.displayPrefix !== this.selectedPrefix;
     const reloadFiat = this.appSettings.settings.displayCurrency !== newCurrency;
     this.appSettings.setAppSetting('displayDenomination', this.selectedDenomination);
+    this.appSettings.settings.qrIntegration = this.selectedQrIntegration;
     this.notifications.sendSuccess(`App display settings successfully updated!`);
 
     if (reloadFiat) {

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -24,7 +24,8 @@ interface AppSettings {
 export class AppSettingsService {
   storeKey = `nanovault-appsettings`;
 
-  settings: AppSettings = {
+  // Default settings
+  defaultSettings: AppSettings = {
     displayDenomination: 'mnano',
     // displayPrefix: 'xrb',
     walletStore: 'localStorage',
@@ -39,6 +40,12 @@ export class AppSettingsService {
     serverWS: null,
     minimumReceive: null,
   };
+
+  // a deep copy clone of the default settings
+  cloneDefaultSettings() : AppSettings {
+    return JSON.parse(JSON.stringify(this.defaultSettings));
+  }
+  settings: AppSettings = this.cloneDefaultSettings(); // deep copy
 
   constructor() { }
 
@@ -77,21 +84,7 @@ export class AppSettingsService {
 
   clearAppSettings() {
     localStorage.removeItem(this.storeKey);
-    this.settings = {
-      displayDenomination: 'mnano',
-      // displayPrefix: 'xrb',
-      walletStore: 'localStorage',
-      displayCurrency: 'USD',
-      defaultRepresentative: null,
-      lockOnClose: 1,
-      lockInactivityMinutes: 30,
-      powSource: 'best',
-      serverName: 'nanovault',
-      serverNode: null,
-      serverAPI: null,
-      serverWS: null,
-      minimumReceive: null,
-    };
+    this.settings = this.cloneDefaultSettings(); // deep copy
   }
 
 }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -18,6 +18,7 @@ interface AppSettings {
   serverNode: string | null;
   serverWS: string | null;
   minimumReceive: string | null;
+  qrIntegration: number; // 0: none, 1: account only, 2: vault URL
 }
 
 @Injectable()
@@ -39,7 +40,14 @@ export class AppSettingsService {
     serverNode: null,
     serverWS: null,
     minimumReceive: null,
+    qrIntegration: 2,
   };
+
+  qrIntegrations = [
+    { value: 0, text: 'No QR Code' }, // none
+    { value: 1, text: 'Account ID Only' }, // account only
+    { value: 2, text: 'Full NanoVault URL' }  // Vault URL
+  ];
 
   // a deep copy clone of the default settings
   cloneDefaultSettings() : AppSettings {

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import set = Reflect.set;
+import * as url from 'url';
 
 export type WalletStore = 'localStorage'|'none';
 export type PoWSource = 'server'|'clientCPU'|'clientWebGL'|'best';
@@ -87,4 +87,10 @@ export class AppSettingsService {
     this.settings = this.cloneDefaultSettings(); // deep copy
   }
 
+  // Get the base URL part of the serverAPI, e.g. https://nanovault.io from https://nanovault.io/api/node-api.
+  getServerApiBaseUrl(): string {
+    let u = url.parse(this.settings.serverAPI);
+    u.pathname = '/';
+    return url.format(u);
+  }
 }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -35,7 +35,7 @@ export class AppSettingsService {
     lockInactivityMinutes: 30,
     powSource: 'best',
     serverName: 'nanovault',
-    serverAPI: null,
+    serverAPI: 'https://nanovault.io/api/node-api',
     serverNode: null,
     serverWS: null,
     minimumReceive: null,


### PR DESCRIPTION
This is a full solution for Issue #76 : the QR code style on the account detail page is configurable.
Options are:
- encode URL of the form https://nanovault.io/send?to=xrb_aaa, so it points to a nanovault Send page with the target account prefilled;
- encodes the account ID only;
- no QR code at all.

The setting can be set below the QR code image, or in the App Settings / Display Settings option as well.

A simple solution to Issue #76 is in PR #77 , whereby always full URL is used with no configurability.