### PR TITLE
use api.coinpaprika.com for currency prices

### DIFF
--- a/src/app/services/price.service.ts
+++ b/src/app/services/price.service.ts
@@ -4,7 +4,7 @@ import {BehaviorSubject} from "rxjs/BehaviorSubject";
 
 @Injectable()
 export class PriceService {
-  apiUrl = `https://api.coinmarketcap.com/v1/`;
+  apiUrl = `'https://api.coinpaprika.com/v1/'`;
 
   price = {
     lastPrice: 1,
@@ -16,16 +16,14 @@ export class PriceService {
 
   async getPrice(currency = 'USD') {
     if (!currency) return; // No currency defined, do not refetch
-    const convertString = currency !== 'USD' && currency !== 'BTC' ? `?convert=${currency}` : ``;
-    const response: any = await this.http.get(`${this.apiUrl}ticker/nano/${convertString}`).toPromise();
+    const convertString = currency !== 'USD' && currency !== 'BTC' ? `?quotes=USD,BTC,${currency}` : ``;
+    const response: any = await this.http.get(`${this.apiUrl}tickers/nano-nano${convertString}`).toPromise();
     if (!response || !response.length) {
       return this.price.lastPrice;
     }
 
-    const quote = response[0];
-    const currencyPrice = quote[`price_${currency.toLowerCase()}`];
-    const btcPrice = quote.price_btc;
-    const usdPrice = quote.price_usd;
+    const currencyPrice = response[`quotes`][${currency}]['price'];
+    const btcPrice = response[`quotes`]['BTC']['price'];
 
     this.price.lastPrice = currencyPrice;
     this.price.lastPriceBTC = btcPrice;
@@ -34,5 +32,4 @@ export class PriceService {
 
     return this.price.lastPrice;
   }
-
 }

--- a/src/app/services/price.service.ts
+++ b/src/app/services/price.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import {HttpClient} from "@angular/common/http";
 import {BehaviorSubject} from "rxjs/BehaviorSubject";
+import { $ } from 'protractor';
 
 @Injectable()
 export class PriceService {
-  apiUrl = `'https://api.coinpaprika.com/v1/'`;
+  apiUrl = `https://api.coinpaprika.com/v1/`;
 
   price = {
     lastPrice: 1,
@@ -16,14 +17,14 @@ export class PriceService {
 
   async getPrice(currency = 'USD') {
     if (!currency) return; // No currency defined, do not refetch
-    const convertString = currency !== 'USD' && currency !== 'BTC' ? `?quotes=USD,BTC,${currency}` : ``;
+    const convertString = currency !== 'USD' && currency !== 'BTC' ? `?quotes=USD,BTC,${currency}` : `?quotes=USD,BTC`;
     const response: any = await this.http.get(`${this.apiUrl}tickers/nano-nano${convertString}`).toPromise();
-    if (!response || !response.length) {
+    if (response.id != "nano-nano") {
       return this.price.lastPrice;
     }
 
-    const currencyPrice = response.quotes.currency.price;
-    const btcPrice = response.quotes.BTC.price;
+    const currencyPrice = response.quotes[currency].price;
+    const btcPrice = response.quotes['BTC'].price;
 
     this.price.lastPrice = currencyPrice;
     this.price.lastPriceBTC = btcPrice;

--- a/src/app/services/price.service.ts
+++ b/src/app/services/price.service.ts
@@ -22,8 +22,8 @@ export class PriceService {
       return this.price.lastPrice;
     }
 
-    const currencyPrice = response[`quotes`][${currency}]['price'];
-    const btcPrice = response[`quotes`]['BTC']['price'];
+    const currencyPrice = response.quotes.currency.price;
+    const btcPrice = response.quotes.BTC.price;
 
     this.price.lastPrice = currencyPrice;
     this.price.lastPriceBTC = btcPrice;


### PR DESCRIPTION
Coinmarketcap API v1 is deprecated and terminated.
While CMC v2 works you need an API token. Coinpaprika is however almost unlimited with 25M calls/month and supports all the currencies currently listed in nanovault.

I think it's better than the coinstats PR #115 

https://coinpaprika.com/api/

Example:
https://api.coinpaprika.com/v1/tickers/nano-nano?quotes=USD,BTC

I could not build and verify the change but I think it works.
