### PR TITLE
New default threshold for v21 local webGL pow

### DIFF
--- a/src/assets/lib/pow/nano-webgl-pow.js
+++ b/src/assets/lib/pow/nano-webgl-pow.js
@@ -3,13 +3,16 @@
 // Author:  numtel <ben@latenightsketches.com>
 // License: MIT
 
-// window.NanoWebglPow(hashHex, callback, progressCallback);
+// window.NanoWebglPow(hashHex, callback, progressCallback, threshold);
 // @param hashHex           String   Previous Block Hash as Hex String
 // @param callback          Function Called when work value found
 //   Receives single string argument, work value as hex
 // @param progressCallback  Function Optional
 //   Receives single argument: n, number of frames so far
 //   Return true to abort
+// @param threshold         String   Optional difficulty threshold (default=0xFFFFFFF8 since v21)
+
+const defaultThreshold = '0xFFFFFFF8'
 
 (function(){
 
@@ -29,7 +32,7 @@ function hex_reverse(hex) {
   return out;
 }
 
-function calculate(hashHex, callback, progressCallback) {
+function calculate(hashHex, callback, progressCallback, threshold = defaultThreshold) {
   const canvas = document.createElement('canvas');
 
   canvas.width = window.NanoWebglPow.width;
@@ -212,7 +215,7 @@ function calculate(hashHex, callback, progressCallback) {
 
       // Threshold test, first 4 bytes not significant,
       //  only calculate digest of the second 4 bytes
-      if((BLAKE2B_IV32_1 ^ v[1] ^ v[17]) > 0xFFFFFFC0u) {
+      if((BLAKE2B_IV32_1 ^ v[1] ^ v[17]) > ` + threshold + `u) {
         // Success found, return pixel data so work value can be constructed
         fragColor = vec4(
           float(x_index + 1u)/255., // +1 to distinguish from 0 (unsuccessful) pixels
@@ -287,7 +290,7 @@ function calculate(hashHex, callback, progressCallback) {
 
     gl.uniform4uiv(work0Location, Array.from(work0));
     gl.uniform4uiv(work1Location, Array.from(work1));
-    
+
     // Check with progressCallback every 100 frames
     if(n%100===0 && typeof progressCallback === 'function' && progressCallback(n))
       return;

--- a/src/assets/lib/pow/nano-webgl-pow.js
+++ b/src/assets/lib/pow/nano-webgl-pow.js
@@ -12,9 +12,8 @@
 //   Return true to abort
 // @param threshold         String   Optional difficulty threshold (default=0xFFFFFFF8 since v21)
 
-const defaultThreshold = '0xFFFFFFF8'
-
 (function(){
+const defaultThreshold = '0xFFFFFFF8'
 
 function array_hex(arr, index, length) {
   let out='';


### PR DESCRIPTION
To solve #122 but only for local webgl library. I couldn't find how that is done for the cpu pow.
The default PoW set to 8x, or fffffff800000000 in this PR with the option to define the threshold when calling the function. If you want to use 1/8x pow for open/receive blocks for example.